### PR TITLE
add affinity fairness test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +227,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,10 +340,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "errno"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "escape8259"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5692dd7b5a1978a5aeb0ce83b7655c58ca8efdcb79d21036ea249da95afec2c6"
+
+[[package]]
+name = "flate2"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "futures"
@@ -471,6 +506,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,6 +605,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
 name = "lock_api"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,6 +631,15 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+dependencies = [
+ "adler2",
+]
 
 [[package]]
 name = "more-asserts"
@@ -730,6 +786,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
+dependencies = [
+ "bitflags",
+ "chrono",
+ "flate2",
+ "hex",
+ "procfs-core",
+ "rustix",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
+dependencies = [
+ "bitflags",
+ "chrono",
+ "hex",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -871,6 +952,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -908,6 +1002,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "parking_lot",
+ "procfs",
  "rand",
  "rstest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ more-asserts = "0.3"
 criterion = "0.5"
 term_size = "0.3.2"
 once_cell = "1.21.3"
+procfs = "0.17"
 
 [dev-dependencies]
 rstest = "0.18"

--- a/src/cases/fairness.rs
+++ b/src/cases/fairness.rs
@@ -1,0 +1,105 @@
+//! Tests for latency scenarios.
+
+use std::time::Duration;
+
+use anyhow::Result;
+
+use crate::test;
+use crate::util::system::{CPUSet, System};
+use crate::workloads::context::Context;
+use crate::workloads::spinner::Spinner;
+use crate::workloads::benchmark::converge;
+use crate::util::system::CPUMask;
+use crate::util::stats::Distribution;
+
+use crate::process;
+
+/// Test that ensures basic fairness for affinitized vs. non-affinitized tasks.
+///
+/// We create one task per logical CPU, and affinitize each one. Then we create one
+/// floating task, and ensure that everyone gets approximate fairness in this case.
+fn fairness() -> Result<()> {
+    let mut ctx = Context::create()?;
+    let mut proc_handles = vec!();
+
+    // Affinitized tasks.
+    for core in System::load()?.cores().iter() {
+        for hyperthread in core.hyperthreads().iter() {
+            let mask = CPUMask::new(hyperthread);
+            proc_handles.push(process!(
+                &mut ctx,
+                None,
+                (mask),
+                move |mut get_iters| {
+                    mask.run(move || {
+                        let spinner = Spinner::default();
+                        loop {
+                            spinner.spin(Duration::from_millis(get_iters() as u64));
+                        }
+                    })
+                }
+            ));
+        }
+    }
+
+    // Floating tasks.
+    for _ in 0..System::load()?.logical_cpus() {
+        proc_handles.push(process!(
+            &mut ctx,
+            None,
+            (),
+            move |mut get_iters| {
+                let spinner = Spinner::default();
+                loop {
+                    spinner.spin(Duration::from_millis(get_iters() as u64));
+                }
+            }
+        ));
+    }
+
+    let metric = |iters| {
+        ctx.start(iters);
+        ctx.wait()?;
+        let mut d = Distribution::<Duration>::new();
+        let times: Vec<f64> = proc_handles.iter().map(|handle| {
+            match handle.stats() {
+                Ok(stats) => {
+                    d.add(stats.total_time);
+                    stats.total_time.as_secs_f64()
+                },
+                Err(_) => 0.0,
+            }
+        }).collect();
+        let mean = times.iter().sum::<f64>() / times.len() as f64;
+        let estimates = d.estimates();
+        eprintln!("{}", estimates.visualize(None));
+        // Return the p10 of the runtimes as a fraction of the average runtime.
+        if let Some(p10) = estimates.percentile(0.1) {
+            Ok(p10.as_secs_f64()/mean)
+        } else {
+            Ok(0.0) // Not enough samples.
+        }
+    };
+
+    // If the p10 of the runtimes is 60% of the average runtime, then we have
+    // achieved **some** level of fairness. If things were starved out completely,
+    // then we would actually expect the p10 to be near zero.
+    let target = 0.60;
+    let final_value = converge(
+        Some(Duration::from_secs_f64(5.0)),
+        Some(Duration::from_secs_f64(10.0)),
+        Some(target),
+        metric,
+    )?;
+    if final_value < target {
+        Err(anyhow::anyhow!(
+            "Failed to achieve target: got {:.2}, expected {:.2}",
+            final_value,
+            target
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+test!("fairness", fairness);

--- a/src/cases/mod.rs
+++ b/src/cases/mod.rs
@@ -104,6 +104,7 @@ macro_rules! benchmark {
 }
 
 pub mod basic;
+pub mod fairness;
 pub mod latency;
 pub mod topology;
 

--- a/src/util/sched.rs
+++ b/src/util/sched.rs
@@ -2,12 +2,18 @@ use nix::unistd::Pid;
 use std::fs;
 use std::io::Read;
 use std::path::Path;
+use std::time::Duration;
+use procfs::{process::Process, ticks_per_second};
 
 use anyhow::{anyhow, Context, Result};
 
 /// Scheduler statistics for a thread.
 #[derive(Debug, Default, Clone)]
 pub struct SchedStats {
+    pub system_time: Duration,
+    pub user_time: Duration,
+    pub total_time: Duration,
+
     pub nr_migrations: u64,
     pub nr_failed_migrations: u64,
     pub nr_forced_migrations: u64,
@@ -42,12 +48,7 @@ impl Sched {
     /// # Returns
     ///
     /// A Result containing the scheduler statistics.
-    pub fn get_thread_stats(pid: Option<Pid>, tid: Option<Pid>) -> Result<SchedStats> {
-        let pid_val = if let Some(pid) = pid {
-            pid.to_string()
-        } else {
-            "self".to_string()
-        };
+    pub fn get_thread_stats(tid: Option<Pid>) -> Result<SchedStats> {
         let tid_val = if let Some(tid) = tid {
             tid.to_string()
         } else {
@@ -55,11 +56,7 @@ impl Sched {
         };
 
         // Path to the scheduler stats file.
-        let path = if tid.is_none() || tid.unwrap() == pid.unwrap() {
-            format!("/proc/{}/sched", pid_val)
-        } else {
-            format!("/proc/{}/task/{}/sched", pid_val, tid_val)
-        };
+        let path = format!("/proc/{}/sched", tid_val);
 
         // Read the scheduler stats for the given pid.
         let mut file = fs::File::open(&path)
@@ -159,6 +156,19 @@ impl Sched {
             }
         }
 
+        let tid_val = if let Some(tid) = tid {
+            Process::new(tid.as_raw() as i32)
+        } else {
+            Process::myself()
+
+        };
+        let proc = tid_val.with_context(|| "Failed to get process information")?;
+        let stat = proc.stat().with_context(|| "Failed to read process stat information")?;
+        let ticks_per_sec = ticks_per_second();
+        stats.system_time = Duration::from_secs_f64(stat.stime as f64 / ticks_per_sec as f64);
+        stats.user_time = Duration::from_secs_f64(stat.utime as f64 / ticks_per_sec as f64);
+        stats.total_time = stats.system_time + stats.user_time;
+
         Ok(stats)
     }
 
@@ -168,7 +178,7 @@ impl Sched {
     ///
     /// A Result containing the scheduler statistics.
     pub fn get_current_thread_stats() -> Result<SchedStats> {
-        Self::get_thread_stats(None, None)
+        Self::get_thread_stats(None)
     }
 
     /// Get aggregated scheduler statistics for all threads in a process.
@@ -196,27 +206,28 @@ impl Sched {
             let entry = entry?;
             let file_name = entry.file_name();
             let tid_str = file_name.to_string_lossy();
-
             if let Ok(tid) = tid_str.parse::<i32>() {
-                if let Ok(stats) = Self::get_thread_stats(pid, Some(Pid::from_raw(tid))) {
-                    aggregated_stats.nr_migrations += stats.nr_migrations;
-                    aggregated_stats.nr_failed_migrations += stats.nr_failed_migrations;
-                    aggregated_stats.nr_forced_migrations += stats.nr_forced_migrations;
-                    aggregated_stats.nr_voluntary_switches += stats.nr_voluntary_switches;
-                    aggregated_stats.nr_involuntary_switches += stats.nr_involuntary_switches;
-                    aggregated_stats.nr_switches += stats.nr_switches;
-                    aggregated_stats.nr_preemptions += stats.nr_preemptions;
-                    aggregated_stats.nr_wakeups += stats.nr_wakeups;
-                    aggregated_stats.nr_wakeups_sync += stats.nr_wakeups_sync;
-                    aggregated_stats.nr_wakeups_migrate += stats.nr_wakeups_migrate;
-                    aggregated_stats.nr_wakeups_local += stats.nr_wakeups_local;
-                    aggregated_stats.nr_wakeups_remote += stats.nr_wakeups_remote;
-                    aggregated_stats.nr_yields += stats.nr_yields;
-                    aggregated_stats.wait_sum += stats.wait_sum;
-                    aggregated_stats.wait_count += stats.wait_count;
-                    if stats.wait_max > aggregated_stats.wait_max {
-                        aggregated_stats.wait_max = stats.wait_max;
-                    }
+                let stats = Self::get_thread_stats(Some(Pid::from_raw(tid)))?;
+                aggregated_stats.system_time += stats.system_time;
+                aggregated_stats.user_time += stats.user_time;
+                aggregated_stats.total_time += stats.total_time;
+                aggregated_stats.nr_migrations += stats.nr_migrations;
+                aggregated_stats.nr_failed_migrations += stats.nr_failed_migrations;
+                aggregated_stats.nr_forced_migrations += stats.nr_forced_migrations;
+                aggregated_stats.nr_voluntary_switches += stats.nr_voluntary_switches;
+                aggregated_stats.nr_involuntary_switches += stats.nr_involuntary_switches;
+                aggregated_stats.nr_switches += stats.nr_switches;
+                aggregated_stats.nr_preemptions += stats.nr_preemptions;
+                aggregated_stats.nr_wakeups += stats.nr_wakeups;
+                aggregated_stats.nr_wakeups_sync += stats.nr_wakeups_sync;
+                aggregated_stats.nr_wakeups_migrate += stats.nr_wakeups_migrate;
+                aggregated_stats.nr_wakeups_local += stats.nr_wakeups_local;
+                aggregated_stats.nr_wakeups_remote += stats.nr_wakeups_remote;
+                aggregated_stats.nr_yields += stats.nr_yields;
+                aggregated_stats.wait_sum += stats.wait_sum;
+                aggregated_stats.wait_count += stats.wait_count;
+                if stats.wait_max > aggregated_stats.wait_max {
+                    aggregated_stats.wait_max = stats.wait_max;
                 }
             }
         }
@@ -332,6 +343,7 @@ mod tests {
     use super::*;
     use std::thread;
     use std::time::Duration;
+    use more_asserts::assert_gt;
 
     #[test]
     fn test_available() {
@@ -353,6 +365,28 @@ mod tests {
         let total_switches = stats.nr_voluntary_switches + stats.nr_involuntary_switches;
         assert!(total_switches > 0, "Expected some context switches");
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_increasing_cpu_time() -> Result<()> {
+        let initial_stats = Sched::get_current_thread_stats()?;
+        let mut sum: u64 = 0;
+        for i in 0..1_000_000 {
+            sum += i;
+        }
+        assert!(sum > 0);
+        let final_stats = Sched::get_current_thread_stats()?;
+        assert_gt!(
+            final_stats.user_time.as_nanos(),
+            initial_stats.user_time.as_nanos(),
+            "User time should increase after CPU-intensive work"
+        );
+        assert_gt!(
+            final_stats.total_time.as_nanos(),
+            initial_stats.total_time.as_nanos(),
+            "Total CPU time should increase after CPU-intensive work"
+        );
         Ok(())
     }
 }

--- a/src/util/system.rs
+++ b/src/util/system.rs
@@ -159,7 +159,7 @@ impl Core {
     }
 
     /// Get the hyperthreads belonging to this core.
-    pub fn hyperthreads(&self) -> &[Hyperthread] {
+    pub fn hyperthreads(&self) -> &Vec<Hyperthread> {
         &self.hyperthreads
     }
 }


### PR DESCRIPTION
In some cases, threads having affinity will be treated differently than threads without affinity. Ensure that this does not hurt threads when a fair schedule is possible: looking at the p10 runtime for the completing groups, require that this is at least 60% of the average runtime.

```
running 1 test
test fairness ...
converge: min_time=5.00, max_time=10.00, threshold=0.60
0ns | 0ns ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁| 0ns
converge: iters=1, elapsed=0.11, metric=NaN
0ns |▁▃▄▄▄▄▄▄▄▄▄▄▅▅▅▅▅▅▅▅▅▅▆▆▆▆▆▆▆▆▆▆▇▇▇▇▇▇▇▇▇▇████ 20ms ███████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆| 40ms
converge: iters=44, elapsed=0.18, metric=0.57
40ms |▁▁▂▂▂▂▃▃▃▃▄▅▅▆▆▇▇▇█ 317.465277ms ████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▅▅▅▅▅▅▅▅▅▄▄▄▄▄▄▄▄▄▃▃▃▃▃▂▂▂▂▁▁▁| 1.25s
converge: iters=1248, elapsed=1.35, metric=0.53
870ms |▁▄▄▅▅▆▆▆▇▇▇▇█ 1.514027777s ██████▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▆▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▃▃▃▁| 5.05s
converge: iters=4611, elapsed=4.72, metric=0.62
1.55s |▁▃▄▄▅▅▆▆▆▆▇▇▇█ 2.7755s ███████▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▅▅▅▅▅▅▅▅▅▅▅▅▅▄▄▄▄▄▄▄▄▄▄▄▄▄▃▃▃▃▃▃▃▂▂▂▂▂▂▁▁▁| 8.99s
converge: iters=4882, elapsed=5.03, metric=0.63
ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 11.76s

[amscanne@devvm16984.vll0 ~/schtest (main)]$ sudo target/debug/schtest  --filter fairness scx_p2dq_6-9_10128
spawning:
 - scx_p2dq_6-9_10128
17:21:25 [INFO] DSQ[0] slice_ns 100000
17:21:25 [INFO] DSQ[1] slice_ns 3200000
17:21:25 [INFO] DSQ[2] slice_ns 6400000
17:21:25 [INFO] Kernel does not support queued wakeup optimization.
17:21:25 [INFO] libbpf: struct_ops p2dq: member priv not found in kernel, skipping it as it's set to zero

17:21:25 [WARN] libbpf: map 'p2dq': BPF skeleton version is old, skipping map auto-attachment...

17:21:25 [INFO] P2DQ scheduler started! Run `scx_p2dq --monitor` for metrics.
scheduler: p2dq

running 1 test
test fairness ...
converge: min_time=5.00, max_time=10.00, threshold=0.60
0ns | 0ns ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁| 0ns
converge: iters=1, elapsed=0.10, metric=NaN
0ns |▁▁▁▁▁▂▂▂▂▂▂▂▂▂▂▃▃▃▃▃▃▃▃▃▃▄▄▄▄▄▄▄▄▄▄▅▅▅▅▅▅▅▅▅▅▆▆▆▆▆▆▆▆▆▆▇▇▇▇▇▇▇▇▇▇█████ 30ms ▃▃▃▃▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▁▁▁▁▁| 40ms
converge: iters=53, elapsed=0.15, metric=0.77
430ms |▁▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇█████████ 908.357142ms ████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▅▅▄▃▁| 1.37s
converge: iters=1749, elapsed=1.86, metric=0.50
1.54s |▁▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇█████████ 3.35422619s ████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▅▄▁| 4.88s
converge: iters=4708, elapsed=4.81, metric=0.49
2.67s |▁▆▆▆▆▆▆▆▆▆▆▆▆▆▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇███████ 5.282730158s ██████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▅▄▁| 8.55s
converge: iters=4898, elapsed=5.00, metric=0.49
4.89s |▁▆▆▆▆▆▆▆▆▆▆▆▆▆▆▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇█████████ 10.488367346s ████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▆▄▁| 15.93s
converge: iters=9796, elapsed=9.89, metric=0.48
9.34s |▁▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇███████████ 22.51325s ███████▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▅▁| 30.5s
converge: iters=19592, elapsed=19.70, metric=0.48
FAILED

failures:

---- fairness ----
Failed to achieve target: got 0.00, expected 0.60

failures:
    fairness

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 4 filtered out; finished in 44.25s

```