### PR TITLE
Don't double-run when we push to private branches and then submit a PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@ name: Build and test
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
 
 jobs:
   check_and_build:


### PR DESCRIPTION
Same problem systing had, need to specify a branch otherwise the build thing gets done twice for every PR with a private branch.