### PR TITLE
Workaround a bug that happens in certain virtualized settings.

### DIFF
--- a/src/util/cgroups.rs
+++ b/src/util/cgroups.rs
@@ -75,7 +75,13 @@ impl Cgroup {
 
         // Create the new cgroup path.
         let cgroup_mount = PathBuf::from("/sys/fs/cgroup");
-        let new_cgroup_path = cgroup_mount.join(&current_cgroup).join(&name);
+        // Note: joining "/" in the middle will remove the /sys/fs/cgroup prefix and cause an error:
+        let new_cgroup_path = if current_cgroup == "/" {
+                cgroup_mount.join(&name)
+            } else {
+                cgroup_mount.join(&current_cgroup).join(&name)
+            };
+
         fs::create_dir_all(&new_cgroup_path).context("failed to create cgroup directory")?;
 
         Ok(Cgroup {


### PR DESCRIPTION
I ran into this with my `virtme-run` based workflow.  It would join together three paths:

```
"/sys/fs/cgroup"  "/"  "schtest-2844930781"
```

Which results in a path in the root file system, such as`/schtest-2844930781`. That in turn causes the `fs::create_dir_all` to fail.
